### PR TITLE
Adds StringOps for parsing primitives.

### DIFF
--- a/jvm/src/test/scala/com/github/benhutchison/mouse/StringJvmTests.scala
+++ b/jvm/src/test/scala/com/github/benhutchison/mouse/StringJvmTests.scala
@@ -1,0 +1,12 @@
+package com.github.benhutchison.mouse
+
+import cats.syntax.all._
+
+class StringJvmTests extends MouseSuite {
+
+  test("parseFloat") {
+    "123.1".parseFloat should ===(123.1f.right[NumberFormatException])
+
+  }
+
+}

--- a/shared/src/main/scala/com/github/benhutchison/mouse/all.scala
+++ b/shared/src/main/scala/com/github/benhutchison/mouse/all.scala
@@ -3,3 +3,4 @@ package com.github.benhutchison.mouse
 trait AllSyntax
   extends OptionSyntax
   with BooleanSyntax
+  with StringSyntax

--- a/shared/src/main/scala/com/github/benhutchison/mouse/package.scala
+++ b/shared/src/main/scala/com/github/benhutchison/mouse/package.scala
@@ -4,5 +4,6 @@ package object mouse {
   object all extends AllSyntax
   object option extends OptionSyntax
   object boolean extends BooleanSyntax
+  object string extends StringSyntax
 
 }

--- a/shared/src/main/scala/com/github/benhutchison/mouse/string.scala
+++ b/shared/src/main/scala/com/github/benhutchison/mouse/string.scala
@@ -1,0 +1,41 @@
+package com.github.benhutchison.mouse
+
+import cats.data.Xor
+
+trait StringSyntax {
+  implicit def stringSyntax(s: String): StringOps = new StringOps(s)
+}
+
+final class StringOps(val s: String) extends AnyVal {
+
+  def parseBoolean: IllegalArgumentException Xor Boolean = Xor.catchOnly[IllegalArgumentException](s.toBoolean)
+
+  def parseBooleanOption: Option[Boolean] = parseBoolean.toOption
+
+  def parseByte: NumberFormatException Xor Byte = parse[Byte](_.toByte)
+
+  def parseByteOption: Option[Byte] = parseByte.toOption
+
+  def parseDouble: NumberFormatException Xor Double = parse[Double](_.toDouble)
+
+  def parseDoubleOption: Option[Double] = parseDouble.toOption
+
+  def parseFloat: NumberFormatException Xor Float = parse[Float](_.toFloat)
+
+  def parseFloatOption: Option[Float] = parseFloat.toOption
+
+  def parseInt: NumberFormatException Xor Int = parse[Int](_.toInt)
+
+  def parseIntOption: Option[Int] = parseInt.toOption
+
+  def parseLong: NumberFormatException Xor Long = parse[Long](_.toLong)
+
+  def parseLongOption: Option[Long] = parseLong.toOption
+
+  def parseShort: NumberFormatException Xor Short = parse[Short](_.toShort)
+
+  def parseShortOption: Option[Short] = parseShort.toOption
+
+  private def parse[A](f: String => A): NumberFormatException Xor A = Xor.catchOnly[NumberFormatException](f(s))
+
+}

--- a/shared/src/test/scala/com/github/benhutchison/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/com/github/benhutchison/mouse/BooleanSyntaxTest.scala
@@ -1,11 +1,8 @@
 package com.github.benhutchison.mouse
 
 import cats.data.Xor
-import com.github.benhutchison.mouse.boolean._
 
-import org.scalatest.{FunSuite, Matchers}
-
-class BooleanSyntaxTest extends FunSuite with Matchers {
+class BooleanSyntaxTest extends MouseSuite {
 
   true.option(1) shouldEqual Option(1)
 

--- a/shared/src/test/scala/com/github/benhutchison/mouse/MouseSuite.scala
+++ b/shared/src/test/scala/com/github/benhutchison/mouse/MouseSuite.scala
@@ -1,0 +1,32 @@
+package com.github.benhutchison.mouse
+
+import cats._
+import cats.std.AllInstances
+import org.scalactic.TripleEqualsSupport.BToAEquivalenceConstraint
+import org.scalactic.{CanEqual, Equivalence}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, FunSuite}
+
+trait MouseSuite
+  extends FunSuite
+    with Matchers
+    with GeneratorDrivenPropertyChecks
+    with AllSyntax
+    with AllInstances {
+  implicit val eq0 = new Eq[NumberFormatException] {
+    override def eqv(x: NumberFormatException, y: NumberFormatException): Boolean =
+      x.getMessage == y.getMessage
+  }
+
+  implicit val eq1 = new Eq[IllegalArgumentException] {
+    override def eqv(x: IllegalArgumentException, y: IllegalArgumentException): Boolean =
+      x.getMessage == y.getMessage
+  }
+
+  final class MouseEquivalence[T](T: Eq[T]) extends Equivalence[T] {
+    def areEquivalent(a: T, b: T): Boolean = T.eqv(a, b)
+  }
+
+  implicit def mouseCanEqual[A, B](implicit A: Eq[A], ev: B <:< A): CanEqual[A, B] =
+    new BToAEquivalenceConstraint[A, B](new MouseEquivalence(A), ev)
+}

--- a/shared/src/test/scala/com/github/benhutchison/mouse/OptionSyntaxTest.scala
+++ b/shared/src/test/scala/com/github/benhutchison/mouse/OptionSyntaxTest.scala
@@ -1,10 +1,6 @@
 package com.github.benhutchison.mouse
 
-import org.scalatest.{FunSuite, Matchers}
-
-import option._
-
-class OptionSyntaxTest extends FunSuite with Matchers {
+class OptionSyntaxTest extends MouseSuite {
 
   Option(1).cata(_.toString, "") shouldEqual "1"
 

--- a/shared/src/test/scala/com/github/benhutchison/mouse/StringTests.scala
+++ b/shared/src/test/scala/com/github/benhutchison/mouse/StringTests.scala
@@ -1,0 +1,110 @@
+package com.github.benhutchison.mouse
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.{Arbitrary, Gen}
+import cats.syntax.all._
+
+class StringTests extends MouseSuite {
+
+  test("parseInt") {
+    "123".parseInt should ===(123.right[NumberFormatException])
+
+    "blah".parseInt should ===(new NumberFormatException("For input string: \"blah\"").left)
+
+    forAll { i: Int =>
+      i.toString.parseInt should ===(i.right[NumberFormatException])
+    }
+
+    forAll { i: Int =>
+      i.toString.parseInt.toOption should ===(i.toString.parseIntOption)
+    }
+
+  }
+
+  test("parseLong") {
+    "123".parseLong should ===(123L.right[NumberFormatException])
+
+    "blah".parseLong should ===(new NumberFormatException("For input string: \"blah\"").left)
+
+    forAll { i: Long =>
+      i.toString.parseLong should ===(i.right[NumberFormatException])
+    }
+
+    forAll { i: Long =>
+      i.toString.parseLong.toOption should ===(i.toString.parseLongOption)
+    }
+
+  }
+
+  test("parseShort") {
+    "123".parseShort should ===(123.toShort.right[NumberFormatException])
+
+    "blah".parseShort should ===(new NumberFormatException("For input string: \"blah\"").left)
+
+    forAll { i: Short =>
+      i.toString.parseShort should ===(i.right[NumberFormatException])
+    }
+
+    forAll { i: Short =>
+      i.toString.parseShort.toOption should ===(i.toString.parseShortOption)
+    }
+
+  }
+
+  test("parseDouble") {
+    "123.1".parseDouble should ===(123.1.right[NumberFormatException])
+
+    "blah".parseDouble should ===(new NumberFormatException("For input string: \"blah\"").left)
+
+    forAll { i: Double =>
+      i.toString.parseDouble should ===(i.right[NumberFormatException])
+    }
+
+    forAll { i: Double =>
+      i.toString.parseDouble.toOption should ===(i.toString.parseDoubleOption)
+    }
+  }
+
+  test("parseFloat") {
+    "blah".parseFloat should ===(new NumberFormatException("For input string: \"blah\"").left)
+
+    forAll { i: Float =>
+      i.toString.parseFloat should ===(i.right[NumberFormatException])
+    }
+
+    forAll { i: Float =>
+      i.toString.parseFloat.toOption should ===(i.toString.parseFloatOption)
+    }
+  }
+
+  test("parseByte") {
+    "123".parseByte should ===(123.toByte.right[NumberFormatException])
+
+    "blah".parseByte should ===(new NumberFormatException("For input string: \"blah\"").left)
+
+    forAll { i: Byte =>
+      i.toString.parseByte should ===(i.right[NumberFormatException])
+    }
+
+    forAll { i: Byte =>
+      i.toString.parseByte.toOption should ===(i.toString.parseByteOption)
+    }
+  }
+
+  test("parseBoolean") {
+    "true".parseBoolean should ===(true.right[IllegalArgumentException])
+    "true".parseBoolean.toOption should ===("true".parseBooleanOption)
+    "false".parseBoolean should ===(false.right[IllegalArgumentException])
+    "false".parseBoolean.toOption should ===("false".parseBooleanOption)
+
+    "TRUE".parseBoolean should ===("true".parseBoolean)
+    "FALSE".parseBoolean should ===("false".parseBoolean)
+
+    val stringGen: Gen[String] = Arbitrary.arbString.arbitrary.filter(s => !s.equalsIgnoreCase("true") && !s.equalsIgnoreCase("false"))
+
+    forAll(stringGen) { s: String =>
+      s.parseBoolean should ===(new IllegalArgumentException("For input string: \"" + s + "\"").left)
+    }
+  }
+
+}


### PR DESCRIPTION
Adds primitive parsing for:
 - `Byte`
 - `Short`
 - `Long`
 - `Int`
 - `Short`
 - `Float`
 - `Double`
 - `Boolean`

Note the float parsing test is in the `jvm` tree because JavaScript does some weird things with floats.

This PR was originally against https://github.com/typelevel/cats/pull/876