### PR TITLE
Boolean fold

### DIFF
--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -6,13 +6,13 @@ trait BooleanSyntax {
 
 final class BooleanOps(val b: Boolean) extends AnyVal {
 
-  def option[A](a: => A): Option[A] = if (b) Some(a) else None
+  final def option[A](a: => A): Option[A] = fold(Some(a), None)
 
   @deprecated("Use `either` instead", "0.6")
-  def xor[L, R](l: =>L, r: =>R): Either[L, R] = either(l, r)
+  final def xor[L, R](l: =>L, r: =>R): Either[L, R] = either(l, r)
 
-  def either[L, R](l: =>L, r: =>R): Either[L, R] = if (b) Right(r) else Left(l)
+  final def either[L, R](l: =>L, r: =>R): Either[L, R] = fold(Right(r), Left(l))
 
-  def fold[A](t: => A, f: => A): A = if (b) t else f
+  final def fold[A](t: => A, f: => A): A = if (b) t else f
 
 }

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -13,4 +13,6 @@ final class BooleanOps(val b: Boolean) extends AnyVal {
 
   def either[L, R](l: =>L, r: =>R): Either[L, R] = if (b) Right(r) else Left(l)
 
+  def fold[A](t: => A, f: => A): A = if (b) t else f
+
 }

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -8,8 +8,12 @@ class BooleanSyntaxTest extends MouseSuite {
 
   false.option(1) shouldEqual Option.empty[Int]
 
-  true.xor("error", 1) shouldEqual Either.right(1)
+  true.either("error", 1) shouldEqual Either.right(1)
 
-  false.xor("error", 1) shouldEqual Either.left("error")
+  false.either("error", 1) shouldEqual Either.left("error")
+
+  true.fold("t", "f") shouldEqual "t"
+  
+  false.fold("t", "f") shouldEqual "f"
 
 }


### PR DESCRIPTION
Adds `fold` method to `BooleanOps`. Also changes (deprecated) `xor` to `either` in tests.

The syntax methods are marked as final and are reimplemented in terms of `fold`.
