### PR TITLE
Fix compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ lazy val cross = crossProject.in(file(".")).
     licenses += ("MIT license", url("http://opensource.org/licenses/MIT")),
     homepage := Some(url("https://github.com/benhutchison/mouse")),
     developers := List(Developer("benhutchison", "Ben Hutchison", "brhutchison@gmail.com", url = url("https://github.com/benhutchison"))),
-    scmInfo := Some(ScmInfo(url("https://github.com/benhutchison/mouse"), "scm:git:https://github.com/benhutchison/mouse.git"))
+    scmInfo := Some(ScmInfo(url("https://github.com/benhutchison/mouse"), "scm:git:https://github.com/benhutchison/mouse.git")),
+    scalacOptions ++= Seq("-feature", "-deprecation", "-language:implicitConversions")
   )
 
 lazy val jvm = cross.jvm

--- a/shared/src/test/scala/mouse/AnySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnySyntaxTest.scala
@@ -12,9 +12,9 @@ class AnySyntaxTest extends MouseSuite {
           |> (_.capitalize)
           |> Function.const("at bat")) shouldEqual "at bat"
 
-  mouse.ignore(true) shouldBe ()
+  mouse.ignore(true) shouldBe (())
 
   1200 |> (_*2) |> (_-5) |> (_/3) shouldBe (((1200 * 2) - 5) / 3)
 
-  "anythingAtAll" |> mouse.ignore shouldBe ()
+  "anythingAtAll" |> mouse.ignore shouldBe (())
 }


### PR DESCRIPTION
Fixed compiler warnings around:

1. Implicit conversions
2. Deprecations (adaptation of argument list by inserting ())

Enabled feature warnings by default.