### PR TITLE
Add try operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The library arose from this [Cats issue](https://github.com/typelevel/cats/issue
 Mouse is published Scala 2.10, 2.11, 2,12. For Scala.jvm:
 
 `"com.github.benhutchison" %% "mouse" % version`
- 
+
 For scala.js:
 
 `"com.github.benhutchison" %%% "mouse" % version`
@@ -24,6 +24,7 @@ Mouse includes enrichments for:
 - [Boolean](./shared/src/main/scala/mouse/boolean.scala)
 - [Option](./shared/src/main/scala/mouse/option.scala)
 - [String](./shared/src/main/scala/mouse/string.scala)
+- [Try](./shared/src/main/scala/mouse/try.scala)
 
 #### Example:
 
@@ -42,6 +43,30 @@ res0: cats.data.Xor[NumberFormatException,Float] = Right(1.0)
 
 scala> "foo".parseIntValidated
 res1: cats.data.Validated[NumberFormatException,Int] = Invalid(java.lang.NumberFormatException: For input string: "foo")
+
+scala> import java.net.URL
+import java.net.URL
+
+scala> import scala.util.Try
+import scala.util.Try
+
+scala> val t1 = Try(new URL("https://www.github.com"))
+t1: scala.util.Try[java.net.URL] = Success(https://www.github.com)
+
+t1.cata(msg => s"URL is valid!", error => s"URL is invalid: ${error.getMessage}")
+res1: String = URL is valid!
+
+scala> t1.either
+res2: Either[Throwable,java.net.URL] = Right(https://www.github.com)
+
+scala> val t2 = Try(new URL("https//www.github.com"))
+t2: scala.util.Try[java.net.URL] = Failure(java.net.MalformedURLException: no protocol: https//www.github.com)
+
+scala> t2.cata(msg => s"URL is valid!", error => s"URL is invalid: ${error.getMessage}")
+res3: String = URL is invalid: no protocol: https//www.github.com
+
+scala> t2.either
+res4: Either[Throwable,java.net.URL] = Left(java.net.MalformedURLException: no protocol: https//www.github.com)
 ```
 
 #### Release Notes
@@ -53,11 +78,11 @@ Version `0.6` (Nov 16) is built against cats `0.8.1` and migrates `Xor` boolean 
 Version `0.5` (Aug 16) is built against cats `0.7.0` but otherwise unchanged.
 
 Version `0.4` (July 2016) includes a breaking package rename from `com.github.benhutchison.mouse` -> `mouse`. Rationale was
-to follow cats and other modern libs convention of short, convenient package names. 
+to follow cats and other modern libs convention of short, convenient package names.
 
 ## Scope of Library
 
-- Provide enrichments to classes from the Scala standard library that convert to Cats datatypes, 
+- Provide enrichments to classes from the Scala standard library that convert to Cats datatypes,
 or otherwise improve the functional programming experience.
 
 - Make it easier to migrate source code between Scalaz and Cats.
@@ -66,7 +91,7 @@ or otherwise improve the functional programming experience.
 
 Issues and pull requests are welcome. Code contributions should be aligned with the above scope to be included, and include unit tests.
 
-This project supports the Typelevel [code of conduct](http://typelevel.org/conduct.html) and aims that its channels 
+This project supports the Typelevel [code of conduct](http://typelevel.org/conduct.html) and aims that its channels
 (mailing list, Gitter, github, etc.) to be welcoming environments for everyone.
- 
+
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val cross = crossProject.in(file(".")).
     scalaVersion := "2.12.1",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats" % "0.9.0",
-      "org.scalatest" %%% "scalatest" % "3.0.0" %  "test"
+      "org.scalatest" %%% "scalatest" % "3.0.0" %  "test",
+      "org.scalacheck" %%% "scalacheck" % "1.13.5" %  "test"
     ),
     publishMavenStyle := true,
     licenses += ("MIT license", url("http://opensource.org/licenses/MIT")),

--- a/shared/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala/mouse/all.scala
@@ -5,3 +5,4 @@ trait AllSyntax
   with OptionSyntax
   with BooleanSyntax
   with StringSyntax
+  with TrySyntax

--- a/shared/src/main/scala/mouse/package.scala
+++ b/shared/src/main/scala/mouse/package.scala
@@ -3,6 +3,7 @@ package object mouse {
   object option extends OptionSyntax
   object boolean extends BooleanSyntax
   object string extends StringSyntax
+  object `try` extends TrySyntax
 
   def ignore(a: Any): Unit = ()
 }

--- a/shared/src/main/scala/mouse/try.scala
+++ b/shared/src/main/scala/mouse/try.scala
@@ -1,0 +1,18 @@
+package mouse
+
+import scala.util.{Failure, Success, Try}
+
+trait TrySyntax {
+  implicit final def trySyntaxMouse[A](ta: Try[A]): TryOps[A] = new TryOps(ta)
+}
+
+final class TryOps[A](val ta: Try[A]) extends AnyVal {
+
+  def cata[B](success: A => B, failure: Throwable => B): B =
+    ta match {
+      case Success(value) => success(value)
+      case Failure(error) => failure(error)
+    }
+
+  def either: Either[Throwable, A] = cata[Either[Throwable, A]](Right(_), Left(_))
+}

--- a/shared/src/test/scala/mouse/TrySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/TrySyntaxTest.scala
@@ -1,0 +1,65 @@
+package mouse
+
+import scala.util.{Failure, Success, Try}
+import org.scalacheck.Gen
+import cats.implicits._
+
+class TrySyntaxTest extends MouseSuite {
+
+  private val exceptionList =
+    Seq(
+      new RuntimeException(_: String),
+      new IllegalArgumentException(_: String),
+      new UnsupportedOperationException(_: String),
+      new ArrayIndexOutOfBoundsException(_: String),
+      new NumberFormatException(_: String)
+    )
+
+  private def genThrowable: Gen[Throwable] = for {
+    message   <- Gen.alphaStr
+    throwable <- Gen.oneOf(exceptionList)
+  } yield throwable(message)
+
+  private def genTrySuccess[T](genT: => Gen[T]): Gen[(T, Try[T])] = for {
+    n  <- genT
+    tr <- Gen.oneOf(Try(n), Success(n))
+  } yield (n, tr)
+
+  private def genTryInt = genTrySuccess[Int](Gen.choose(-10000, 10000))
+
+  private def genTryString = genTrySuccess[String](Gen.alphaStr)
+
+  private def genTryBoolean = genTrySuccess[Boolean](Gen.oneOf(true, false))
+
+  private def genTryFailure[T]: Gen[(Throwable, Try[T])] = for {
+    th <- genThrowable
+    tr <- Gen.oneOf(Try[T](throw th), Failure[T](th))
+  } yield (th, tr)
+
+  private def randomNumber(min: Int, max: Int): Int = Gen.choose(min, max).sample.get
+
+  forAll(genTryInt) { case (n, t) =>
+    t.cata(identity, _ => n * n) shouldEqual n
+  }
+
+  forAll(genTryFailure[Int]) { case (th, tr) =>
+    val rnd = randomNumber(50000, 60000)
+    tr.cata(identity, _ => rnd) shouldEqual (rnd)
+  }
+
+  forAll(genTryString) { case (msg, tr) =>
+    tr.either shouldEqual Right(msg)
+  }
+
+  forAll(genTryFailure[String]) { case (th, tr) =>
+    tr.either shouldEqual Left(th)
+  }
+
+  implicit class ExtraTest[A](a: A) {
+    def shouldBeA[T](implicit ev: T =:= A) = succeed
+  }
+
+  forAll(genTryBoolean, minSuccessful(10)) { case (_, t) =>
+    t.either.shouldBeA[Either[Throwable, Boolean]]
+  }
+}


### PR DESCRIPTION
Added the following try operations:

1. cata
2. either

Updated examples and used pattern matching to get around missing __fold__
method on scala.util.Try in Scala 2.10 and 2.11.