### PR TITLE
Rename either to toEither on TryOps

### DIFF
--- a/shared/src/main/scala/mouse/try.scala
+++ b/shared/src/main/scala/mouse/try.scala
@@ -14,5 +14,5 @@ final class TryOps[A](val ta: Try[A]) extends AnyVal {
       case Failure(error) => failure(error)
     }
 
-  def either: Either[Throwable, A] = cata[Either[Throwable, A]](Right(_), Left(_))
+  def toEither: Either[Throwable, A] = cata[Either[Throwable, A]](Right(_), Left(_))
 }

--- a/shared/src/test/scala/mouse/TrySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/TrySyntaxTest.scala
@@ -48,11 +48,11 @@ class TrySyntaxTest extends MouseSuite {
   }
 
   forAll(genTryString) { case (msg, tr) =>
-    tr.either shouldEqual Right(msg)
+    tr.toEither shouldEqual Right(msg)
   }
 
   forAll(genTryFailure[String]) { case (th, tr) =>
-    tr.either shouldEqual Left(th)
+    tr.toEither shouldEqual Left(th)
   }
 
   implicit class ExtraTest[A](a: A) {
@@ -60,6 +60,6 @@ class TrySyntaxTest extends MouseSuite {
   }
 
   forAll(genTryBoolean, minSuccessful(10)) { case (_, t) =>
-    t.either.shouldBeA[Either[Throwable, Boolean]]
+    t.toEither.shouldBeA[Either[Throwable, Boolean]]
   }
 }


### PR DESCRIPTION
Renamed the **either** method on **TryOps** to **toEither** to match
the **toEither** method added to **scala.util.Try** in Scala 2.12.

The **TrySyntax** will add an implicit conversion on **scala.util.Try**
to add the **toEither** method for Scala 2.10 and 2.11 and will use the
default **toEither** method when on Scala 2.12.