### PR TITLE
Inlining all of the things

### DIFF
--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -6,13 +6,13 @@ trait BooleanSyntax {
 
 final class BooleanOps(val b: Boolean) extends AnyVal {
 
-  final def option[A](a: => A): Option[A] = fold(Some(a), None)
+  @inline final def option[A](a: => A): Option[A] = fold(Some(a), None)
 
   @deprecated("Use `either` instead", "0.6")
-  final def xor[L, R](l: =>L, r: =>R): Either[L, R] = either(l, r)
+  @inline final def xor[L, R](l: =>L, r: =>R): Either[L, R] = either(l, r)
 
-  final def either[L, R](l: =>L, r: =>R): Either[L, R] = fold(Right(r), Left(l))
+  @inline final def either[L, R](l: =>L, r: =>R): Either[L, R] = fold(Right(r), Left(l))
 
-  final def fold[A](t: => A, f: => A): A = if (b) t else f
+  @inline final def fold[A](t: => A, f: => A): A = if (b) t else f
 
 }

--- a/shared/src/main/scala/mouse/option.scala
+++ b/shared/src/main/scala/mouse/option.scala
@@ -8,24 +8,24 @@ trait OptionSyntax {
 
 final class OptionOps[A](val oa: Option[A]) extends AnyVal {
 
-  def cata[B](some: A => B, none: => B): B = oa.fold[B](none)(some)
+  @inline final def cata[B](some: A => B, none: => B): B = oa.fold[B](none)(some)
 
   def toTry(ex: =>Throwable): Try[A] = oa match {
     case Some(x) => Success(x)
     case None => Failure(ex)
   }
 
-  def toTryMsg(msg: =>String): Try[A] = toTry(new RuntimeException(msg))
+  @inline final def toTryMsg(msg: =>String): Try[A] = toTry(new RuntimeException(msg))
 
   /**
    * Same as oa.toRight except that it fixes the type to Either[B, A]
    * On Scala prior to 2.12, toRight returns `Serializable with Product with Either[B, A]`
    */
-  def right[B](b: => B) : Either[B, A] = oa.toRight(b)
+  @inline final def right[B](b: => B) : Either[B, A] = oa.toRight(b)
 
   /**
    * Same as oa.toLeft except that it fixes the type to Either[A, B]
    * On Scala prior to 2.12, toLeft returns `Serializable with Product with Either[A, B]`
    */
-  def left[B](b: => B) : Either[A, B] = oa.toLeft(b)
+  @inline final def left[B](b: => B) : Either[A, B] = oa.toLeft(b)
 }

--- a/shared/src/main/scala/mouse/string.scala
+++ b/shared/src/main/scala/mouse/string.scala
@@ -9,47 +9,47 @@ trait StringSyntax {
 
 final class StringOps(val s: String) extends AnyVal {
 
-  def parseBoolean: IllegalArgumentException Either Boolean = Either.catchOnly[IllegalArgumentException](s.toBoolean)
+  @inline final def parseBoolean: IllegalArgumentException Either Boolean = Either.catchOnly[IllegalArgumentException](s.toBoolean)
 
-  def parseBooleanValidated: Validated[IllegalArgumentException, Boolean] = parseBoolean.toValidated
+  @inline final def parseBooleanValidated: Validated[IllegalArgumentException, Boolean] = parseBoolean.toValidated
 
-  def parseBooleanOption: Option[Boolean] = parseBoolean.toOption
+  @inline final def parseBooleanOption: Option[Boolean] = parseBoolean.toOption
 
-  def parseByte: NumberFormatException Either Byte = parse[Byte](_.toByte)
+  @inline final def parseByte: NumberFormatException Either Byte = parse[Byte](_.toByte)
 
-  def parseByteValidated: Validated[NumberFormatException, Byte] = parseByte.toValidated
+  @inline final def parseByteValidated: Validated[NumberFormatException, Byte] = parseByte.toValidated
 
-  def parseByteOption: Option[Byte] = parseByte.toOption
+  @inline final def parseByteOption: Option[Byte] = parseByte.toOption
 
-  def parseDouble: NumberFormatException Either Double = parse[Double](_.toDouble)
+  @inline final def parseDouble: NumberFormatException Either Double = parse[Double](_.toDouble)
 
-  def parseDoubleValidated: Validated[NumberFormatException, Double] = parseDouble.toValidated
+  @inline final def parseDoubleValidated: Validated[NumberFormatException, Double] = parseDouble.toValidated
 
-  def parseDoubleOption: Option[Double] = parseDouble.toOption
+  @inline final def parseDoubleOption: Option[Double] = parseDouble.toOption
 
-  def parseFloat: NumberFormatException Either Float = parse[Float](_.toFloat)
+  @inline final def parseFloat: NumberFormatException Either Float = parse[Float](_.toFloat)
 
-  def parseFloatValidated: Validated[NumberFormatException, Float] = parseFloat.toValidated
+  @inline final def parseFloatValidated: Validated[NumberFormatException, Float] = parseFloat.toValidated
 
-  def parseFloatOption: Option[Float] = parseFloat.toOption
+  @inline final def parseFloatOption: Option[Float] = parseFloat.toOption
 
-  def parseInt: NumberFormatException Either Int = parse[Int](_.toInt)
+  @inline final def parseInt: NumberFormatException Either Int = parse[Int](_.toInt)
 
-  def parseIntValidated: Validated[NumberFormatException, Int] = parseInt.toValidated
+  @inline final def parseIntValidated: Validated[NumberFormatException, Int] = parseInt.toValidated
 
-  def parseIntOption: Option[Int] = parseInt.toOption
+  @inline final def parseIntOption: Option[Int] = parseInt.toOption
 
-  def parseLong: NumberFormatException Either Long = parse[Long](_.toLong)
+  @inline final def parseLong: NumberFormatException Either Long = parse[Long](_.toLong)
 
-  def parseLongValidated: Validated[NumberFormatException, Long] = parseLong.toValidated
+  @inline final def parseLongValidated: Validated[NumberFormatException, Long] = parseLong.toValidated
 
-  def parseLongOption: Option[Long] = parseLong.toOption
+  @inline final def parseLongOption: Option[Long] = parseLong.toOption
 
-  def parseShort: NumberFormatException Either Short = parse[Short](_.toShort)
+  @inline final def parseShort: NumberFormatException Either Short = parse[Short](_.toShort)
 
-  def parseShortValidated: Validated[NumberFormatException, Short] = parseShort.toValidated
+  @inline final def parseShortValidated: Validated[NumberFormatException, Short] = parseShort.toValidated
 
-  def parseShortOption: Option[Short] = parseShort.toOption
+  @inline final def parseShortOption: Option[Short] = parseShort.toOption
 
   private def parse[A](f: String => A): NumberFormatException Either A = Either.catchOnly[NumberFormatException](f(s))
 

--- a/shared/src/main/scala/mouse/try.scala
+++ b/shared/src/main/scala/mouse/try.scala
@@ -3,16 +3,16 @@ package mouse
 import scala.util.{Failure, Success, Try}
 
 trait TrySyntax {
-  implicit final def trySyntaxMouse[A](ta: Try[A]): TryOps[A] = new TryOps(ta)
+  @inline implicit final def trySyntaxMouse[A](ta: Try[A]): TryOps[A] = new TryOps(ta)
 }
 
 final class TryOps[A](val ta: Try[A]) extends AnyVal {
 
-  def cata[B](success: A => B, failure: Throwable => B): B =
+  final def cata[B](success: A => B, failure: Throwable => B): B =
     ta match {
       case Success(value) => success(value)
       case Failure(error) => failure(error)
     }
 
-  def toEither: Either[Throwable, A] = cata[Either[Throwable, A]](Right(_), Left(_))
+  @inline final def toEither: Either[Throwable, A] = cata[Either[Throwable, A]](Right(_), Left(_))
 }


### PR DESCRIPTION
This does `@inline` on most of the methods. While it can be argued that this is redundant due to JIT, here are some counter arguments

1. Making the JIT do less work is always preferable
2. May not always imply for other platforms (scala.js and scala-native)
3. JIT can sometimes fail if the methods aren't call enough times

The only downside is if the implementations of the `@inline` method changes, but this is highly unlikely in such a library (and it would be done in a new version of mouse anyways)